### PR TITLE
This fixes the lodash dependency failing to load

### DIFF
--- a/src/modules/rest-api/stores/rest-api-cache-store.js
+++ b/src/modules/rest-api/stores/rest-api-cache-store.js
@@ -1,7 +1,7 @@
 /**
  * Stores cached entities for the Rest API
  */
-import isArray from 'lodash/lang/isarray';
+import isArray from 'lodash/lang/isArray';
 import { Store, toImmutable } from 'nuclear-js';
 import actionTypes from '../action-types';
 


### PR DESCRIPTION
Fixes lodash dependency not loading when on systems with case sensitive pathing.  This was causing me issues on Ubuntu 15.04 because the casing did not match the file system path.
