### PR TITLE
Bug fix: Issue #946

### DIFF
--- a/src/modules/navigation/url-sync.js
+++ b/src/modules/navigation/url-sync.js
@@ -101,11 +101,11 @@ export function startSync(reactor) {
       (moreInfoEntitySelected) => {
         if (moreInfoEntitySelected) {
           history.pushState(history.state, PAGE_TITLE, window.location.pathname);
-        } else if (sync.ignoreNextDeselectEntity) {
-          sync.ignoreNextDeselectEntity = false;
-        } else {
+        } else if (!sync.ignoreNextDeselectEntity) {
+          sync.ignoreNextDeselectEntity = true;
           history.back();
         }
+        sync.ignoreNextDeselectEntity = false;
       }
     ),
   };


### PR DESCRIPTION
In Firefox, multiple Back actions were being fired when a user clicks outside of a component popup. Apparently Firefox remembers the IF/ELSE conditions that trigger the Back event, causing these conditions to persist causing an infinite loop of Back events. The IF/ELSE construct has been slightly reworked here to prevent multiple triggers.
