### PR TITLE
Issues #1132 & #946 (home-assistant)

### DIFF
--- a/src/modules/navigation/url-sync.js
+++ b/src/modules/navigation/url-sync.js
@@ -19,10 +19,7 @@ function getSync(reactor) {
 }
 
 function pageState(pane, view) {
-  const state = { pane };
-  if (pane === 'states') {
-    state.view = view;
-  }
+  const state = { pane, view };
   return state;
 }
 


### PR DESCRIPTION
The `state` object was being redeclared on every new page in `pageState()`, but the `state.view` property was only being assigned if `pane === 'states'`. This was blowing away `state.view` causing it to be `undefined`. This in turn was preventing `selectView()` from firing in `popstateChangeListener()` because `view` was `undefined`.

To fix this, I just removed the `if (pane === 'states')` check, so that `state.view` is always defined, which results in a `null` value on other panes instead of `undefined`. 

This was intended as a fix for Issue #1132, but it apparently also addresses #946 as well, which was causing a Back loop when clicking out of a component popup in Firefox.
