### PR TITLE
Issue 1132

### DIFF
--- a/src/modules/navigation/url-sync.js
+++ b/src/modules/navigation/url-sync.js
@@ -19,10 +19,7 @@ function getSync(reactor) {
 }
 
 function pageState(pane, view) {
-  const state = { pane };
-  if (pane === 'states') {
-    state.view = view;
-  }
+  const state = { pane, view };
   return state;
 }
 

--- a/src/modules/navigation/url-sync.js
+++ b/src/modules/navigation/url-sync.js
@@ -19,7 +19,10 @@ function getSync(reactor) {
 }
 
 function pageState(pane, view) {
-  const state = { pane, view };
+  const state = { pane };
+  if (pane === 'states') {
+    state.view = view ? view : null;
+  }
   return state;
 }
 


### PR DESCRIPTION
Alternate fix for #1132. Only prevents `undefined` for the /states pane.
