### PR TITLE
Encode api_password embedded in api url

### DIFF
--- a/src/modules/stream/actions.js
+++ b/src/modules/stream/actions.js
@@ -30,7 +30,7 @@ export function start(reactor, { syncOnInitialConnect = true } = {}) {
   // Why? Because the error event listener on EventSource cannot be trusted.
   const reconnect = debounce(start.bind(null, reactor), RETRY_TIME);
   const scheduleHealthCheck = debounce(start.bind(null, reactor), MAX_INACTIVITY_TIME);
-  const authToken = reactor.evaluate(authGetters.authToken);
+  const authToken = encodeURIComponent(reactor.evaluate(authGetters.authToken));
   const source = new EventSource(`/api/stream?api_password=${authToken}&restrict=${EVENTS}`);
   let syncOnConnect = syncOnInitialConnect;
 


### PR DESCRIPTION
Passwords that include URL special characters fail to authenticate for streaming updates. See issue below.

Fixes https://github.com/home-assistant/home-assistant/issues/2320
