### PR TITLE
Allow polymer to check custom_ui object provided by /api/bootstrap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import * as sync from './modules/sync';
 import * as template from './modules/template';
 import * as view from './modules/view';
 import * as voice from './modules/voice';
+import * as customUi from './modules/custom-ui';
 
 export default class HomeAssistant {
   constructor() {
@@ -75,6 +76,7 @@ export default class HomeAssistant {
     exposeModules(this, reactor, {
       auth,
       config,
+      customUi,
       entity,
       entityHistory,
       errorLog,

--- a/src/modules/custom-ui/action-types.js
+++ b/src/modules/custom-ui/action-types.js
@@ -1,0 +1,5 @@
+import keyMirror from 'keymirror';
+
+export default keyMirror({
+  CUSTOM_UI_LOADED: null,
+});

--- a/src/modules/custom-ui/actions.js
+++ b/src/modules/custom-ui/actions.js
@@ -1,0 +1,5 @@
+import actionTypes from './action-types';
+
+export function customUiLoaded(reactor, customUi) {
+  reactor.dispatch(actionTypes.CUSTOM_UI_LOADED, { customUi });
+}

--- a/src/modules/custom-ui/getters.js
+++ b/src/modules/custom-ui/getters.js
@@ -1,0 +1,4 @@
+export const customUi = [
+  'customUi',
+];
+

--- a/src/modules/custom-ui/index.js
+++ b/src/modules/custom-ui/index.js
@@ -1,0 +1,12 @@
+import customUi from './stores/custom-ui-store';
+import * as _actions from './actions';
+import * as _getters from './getters';
+
+export function register(reactor) {
+  reactor.registerStores({
+    customUi,
+  });
+}
+
+export const actions = _actions;
+export const getters = _getters;

--- a/src/modules/custom-ui/stores/custom-ui-store.js
+++ b/src/modules/custom-ui/stores/custom-ui-store.js
@@ -1,0 +1,22 @@
+import nuclearJS from 'nuclear-js';
+import actionTypes from '../action-types';
+
+const { Store, toImmutable } = nuclearJS;
+
+const INSTANCE = new Store({
+  getInitialState() {
+    return toImmutable({});
+  },
+
+  initialize() {
+    /* eslint-disable no-use-before-define */
+    this.on(actionTypes.CUSTOM_UI_LOADED, customUiLoaded);
+    /* eslint-enable no-use-before-define */
+  },
+});
+
+export default INSTANCE;
+
+function customUiLoaded(state, { customUi }) {
+  return toImmutable(customUi);
+}

--- a/src/modules/sync/actions.js
+++ b/src/modules/sync/actions.js
@@ -6,6 +6,8 @@ import { actions as serviceActions } from '../service';
 import { actions as eventActions } from '../event';
 import { actions as configActions } from '../config';
 import { actions as navigationActions } from '../navigation';
+import { actions as customUiActions } from '../custom-ui';
+
 
 export function fetchAll(reactor) {
   reactor.dispatch(actionTypes.API_FETCH_ALL_START, {});
@@ -17,6 +19,7 @@ export function fetchAll(reactor) {
       eventActions.replaceData(reactor, data.events);
       configActions.configLoaded(reactor, data.config);
       navigationActions.panelsLoaded(reactor, data.panels);
+      customUiActions.customUiLoaded(reactor, data.custom_ui);
 
       reactor.dispatch(actionTypes.API_FETCH_ALL_SUCCESS, {});
     });


### PR DESCRIPTION
This PR is a prerequirement for home-assistant/home-assistant-polymer#175

It takes the custom_ui object from api/bootstrap (Added in home-assistant/home-assistant#5479) and make it available to Polymer.